### PR TITLE
feat: add receive to type enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abi-decoder-ts",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Typescript Solidity ABI Decoder",
   "license": "GPL-3.0",
   "main": "cjs/index.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export namespace ABI {
-  export type Type = "function" | "constructor" | "event" | "fallback";
+  export type Type = "function" | "constructor" | "event" | "fallback" | "receive";
   export type StateMutabilityType = "pure" | "view" | "nonpayable" | "payable";
 
   export interface Item {


### PR DESCRIPTION
**Description**
Add `receive` to `Item`'s `type` enum (https://docs.soliditylang.org/en/v0.8.10/contracts.html#receive-ether-function).

**Notes**
I bumped the patch version, though I wasn't clear on the `auto-changelog` workflow.